### PR TITLE
Change mocking of token generation

### DIFF
--- a/src/main/java/health/ere/ps/service/dgc/DigitalGreenCertificateService.java
+++ b/src/main/java/health/ere/ps/service/dgc/DigitalGreenCertificateService.java
@@ -211,15 +211,10 @@ public class DigitalGreenCertificateService {
     }
 
     private String getToken() {
-
         RequestBearerTokenFromIdpEvent event = new RequestBearerTokenFromIdpEvent();
 
         requestBearerTokenFromIdp.fire(event);
 
         return Optional.ofNullable(event.getBearerToken()).orElseThrow(DigitalGreenCertificateInternalAuthenticationException::new);
-    }
-
-    public void setRequestBearerTokenFromIdp(Event<RequestBearerTokenFromIdpEvent> requestBearerTokenFromIdp) {
-        this.requestBearerTokenFromIdp = requestBearerTokenFromIdp;
     }
 }


### PR DESCRIPTION
This implementation does not need a setter for the event in the service.

Closes #20