### PR TITLE
Use non-mocked exception in test to avoid NPE

### DIFF
--- a/src/test/java/health/ere/ps/service/idp/IdPServiceTest.java
+++ b/src/test/java/health/ere/ps/service/idp/IdPServiceTest.java
@@ -173,7 +173,8 @@ class IdPServiceTest {
 
     @Test
     void requestBearerTokenWithException() throws IdpJoseException, IdpClientException, IdpException {
-        IdpClientException idpClientException = mock(IdpClientException.class);
+        // no mock to avoid NPE when writing the log
+        IdpClientException idpClientException = new IdpClientException("test");
 
         when(idpClient.initializeClient()).thenThrow(idpClientException);
 


### PR DESCRIPTION
Closes #33 